### PR TITLE
build: NodeJS runtime bundling

### DIFF
--- a/esbuild/build.js
+++ b/esbuild/build.js
@@ -29,7 +29,7 @@ const common = {
     const runtime = await esbuild.build({
         ...common,
         ...runtimeCommon,
-        outfile: 'build/runtime/index-node.js',
+        outfile: 'build/runtime/index.js',
         minify: true,
         metafile: true,
     });
@@ -37,7 +37,7 @@ const common = {
     esbuild.build({
         ...common,
         ...runtimeCommon,
-        outfile: 'build/runtime/index.js',
+        outfile: 'build/runtime/index-browser.js',
         external: ['katex'],
         platform: 'neutral',
     });

--- a/esbuild/build.js
+++ b/esbuild/build.js
@@ -57,7 +57,7 @@ const common = {
             RUNTIME: JSON.stringify(
                 Object.keys(runtime.metafile.outputs)
                     .filter((file) => !file.match(/\.map$/))
-                    .map((file) => file.replace(/^runtime\//, '')),
+                    .map((file) => file.replace(/^build\/runtime\//, '')),
             ),
         },
     };

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
       "default": "./build/plugin/index.js"
     },
     "./runtime": {
-      "node": "./build/runtime/index-node.js",
-      "default": "./build/runtime/index.js"
+      "node": "./build/runtime/index.js",
+      "default": "./build/runtime/index-browser.js"
     },
-    "./runtime/styles": "./build/runtime/index-node.css",
+    "./runtime/styles": "./build/runtime/index.css",
     "./react": "./build/react/index.js",
     "./hooks": "./build/react/index.js"
   },


### PR DESCRIPTION
- fix `RUNTIME` mapping regexp
- fix CSS and fonts missing from NodeJS bundle

Release-As: 1.3.1